### PR TITLE
create cmdline.txt if it doesnt exist

### DIFF
--- a/ansible/roles/k3s-common/tasks/main.yml
+++ b/ansible/roles/k3s-common/tasks/main.yml
@@ -11,6 +11,7 @@
     regexp: '((.)+?)(\scgroup_\w+=\w+)*$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: yes
+    create: yes
 
 - name: Reboot the node
   reboot:


### PR DESCRIPTION
This was failing for me as the file did not exist. Not sure if it should have already existed or not.